### PR TITLE
Buffer -> npm:base64url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "base64url": "^3.0.1",
         "crypto-js": "^4.1.1"
       },
       "devDependencies": {
@@ -29,6 +30,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
       "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
       "dev": true
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/crypto-js": {
       "version": "4.1.1",
@@ -76,6 +85,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
       "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
       "dev": true
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "crypto-js": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "base64url": "^3.0.1",
     "crypto-js": "^4.1.1"
   }
 }

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -22,6 +22,7 @@
 
 import { Algorithm } from './types';
 import { algo as CryptoJS, enc as CryptoJSEncoders } from 'crypto-js';
+import Base64URL from 'base64url';
 
 export default class JWT {
     public static signSync(
@@ -296,14 +297,16 @@ export default class JWT {
         const computedSignature = hmac
             .finalize()
             .toString(CryptoJSEncoders.Base64);
-        const str = Buffer.from(computedSignature, 'base64').toString(
+        /*const str = Buffer.from(computedSignature, 'base64').toString(
             'base64url'
-        );
+        );*/
+        const str = Base64URL.fromBase64(computedSignature);
         return signature === str;
     }
 
     private static decodeSegment(segment: string): any {
-        const str = Buffer.from(segment, 'base64url').toString('utf8');
+        //const str = Buffer.from(segment, 'base64url').toString('utf8');
+        const str = Base64URL.decode(segment);
         return JSON.parse(str);
     }
 
@@ -316,10 +319,12 @@ export default class JWT {
         const hmac = CryptoJS.HMAC.create(algo, secret);
         hmac.update(data);
         const finalized = hmac.finalize();
-        return Buffer.from(
+        /*const out = Buffer.from(
             finalized.toString(CryptoJSEncoders.Base64),
             'base64'
-        ).toString('base64url');
+        ).toString('base64url');*/
+        const out = Base64URL.fromBase64(finalized.toString(CryptoJSEncoders.Base64));
+        return out;
     }
 
     private static determineAlgorithm(algorithm: Algorithm): any {
@@ -337,7 +342,9 @@ export default class JWT {
 
     private static encodeSegment(segment: any): string {
         const str = JSON.stringify(segment);
-        return Buffer.from(str, 'utf8').toString('base64url');
+        //const out = Buffer.from(str, 'utf8').toString('base64url');
+        const out = Base64URL.encode(str);
+        return out;
     }
 
     private static buildPayload(data: any, options: any): any {


### PR DESCRIPTION
Using `Buffer` to encode/decode Base64Url encoded strings fails with this error:
```
  "exceptions": [
    {
      "name": "TypeError",
      "message": "Unknown encoding: base64url",
      "timestamp": 1658484678721
    }
  ],
```

This push moves to the [base64url](https://www.npmjs.com/package/base64url) NPM package.